### PR TITLE
Fix a multiPV bug in lazy SMP

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -370,7 +370,7 @@ void Thread::search() {
           std::stable_sort(rootMoves.begin(), rootMoves.begin() + PVIdx + 1);
 
           if (!mainThread)
-              break;
+              continue;
 
           if (Signals.stop)
               sync_cout << "info nodes " << Threads.nodes_searched()


### PR DESCRIPTION
Where the helper threads were not doing multiPV at all.

Co-Authored-By: Marco Costalba <1099265+mcostalba@users.noreply.github.com>

