### PR TITLE
Remove questionable gcc flags from profile-build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -492,7 +492,7 @@ gcc-profile-make:
 
 gcc-profile-use:
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-use -fno-peel-loops -fno-tracer' \
+	EXTRACXXFLAGS='-fprofile-use' \
 	EXTRALDFLAGS='-lgcov' \
 	all
 


### PR DESCRIPTION
Optimization options for official stockfish should be consistent, easy, future proof and simple.

We don't want to optimize for any specific version of gcc

Co-Authored-By: Joona Kiiski <2694706+zamar@users.noreply.github.com>

